### PR TITLE
Add jQuery-based post list view with CORS and fake data support

### DIFF
--- a/core/blog/urls.py
+++ b/core/blog/urls.py
@@ -6,6 +6,7 @@ from blog.views import (
     CreatePostView,
     UpdatePostView,
     DeletePostView,
+    PostListApiView,
 )
 
 app_name = "blog"
@@ -13,6 +14,7 @@ app_name = "blog"
 urlpatterns = [
     path("", HomeView.as_view(), name="index"),
     path("post-list/", PostListView.as_view(), name="post-list"),
+    path("post/api/", PostListApiView.as_view(), name="post-list-api"),
     path("post-detail/<int:pk>/", PostDetailView.as_view(), name="post-detail"),
     path("create/", CreatePostView.as_view(), name="create-post"),
     path("update/<int:pk>/", UpdatePostView.as_view(), name="update-post"),

--- a/core/blog/views.py
+++ b/core/blog/views.py
@@ -115,3 +115,9 @@ class DeletePostView(PostPermissionMixin, DeleteView):
 
     def get_queryset(self):
         return Post.objects.filter(author=self.request.user.profile, status=True)
+
+
+class PostListApiView(TemplateView):
+    """API view to list all posts."""
+
+    template_name = "blog/post_list_api.html"

--- a/core/core/settings.py
+++ b/core/core/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     "drf_yasg",
     "django_filters",
     "mail_templated",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
@@ -67,6 +68,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
 ]
 
 ROOT_URLCONF = "core.urls"
@@ -229,3 +232,7 @@ EMAIL_HOST = "smtp4dev"
 EMAIL_HOST_USER = ""
 EMAIL_HOST_PASSWORD = ""
 EMAIL_PORT = 25
+
+
+# django-cors-headers settings
+CORS_ALLOW_ALL_ORIGINS = True

--- a/core/templates/blog/post_list_api.html
+++ b/core/templates/blog/post_list_api.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Document</title>
+</head>
+<body>
+	
+		
+	<h1>Blog Post List API</h1>
+	<ol id="post-list">
+		<h3>Title: </h3>
+		
+	</ol>
+
+
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+	 integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+	  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+	<script>
+		$.get('/blog/api/v1/post/',
+			function(data, textStatus, jqXHR) {
+				wrapper = $('#post-list');
+				for (post of data['results']){
+					wrapper.append(`<li><a href="${post.detail_url}"><h4>${post.title}</h4></a></li>`);
+					
+
+				}
+				
+
+
+			}
+		)
+	</script>
+
+	
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ djangorestframework-simplejwt
 django-filter
 drf-yasg[validation]
 
+
 # Date and Time Management
 jdatetime
 
@@ -35,3 +36,7 @@ flake8 # We could just go with Ruff here instead of Flake8
 pytest-django
 pytest
 Faker
+
+
+# For CORS support
+django-cors-headers 


### PR DESCRIPTION
- Added new HTML template `post_list_api.html` to display blog posts using jQuery and AJAX.
- Implemented basic JS script to fetch posts via `/blog/api/v1/post/` endpoint.
- Installed and configured `django-cors-headers` to allow frontend-backend communication (CORS_ALLOW_ALL_ORIGINS = True).
- Registered a new class-based view `PostListApiView` in blog/views.py and routed it via blog/urls.py.
- Installed and added `Faker` library to requirements for generating fake data.