### PR TITLE
Add cache_page decorator to API views for performance optimization

### DIFF
--- a/core/accounts/api/v1/urls/accounts.py
+++ b/core/accounts/api/v1/urls/accounts.py
@@ -21,7 +21,7 @@ app_name = "accounts-api-v1"
 urlpatterns = [
     path("registration/", RegisterApiView.as_view(), name="registration"),
     # activation
-    path("test-email/", TestEmailSend.as_view(), name="test-email"),
+    path("test-email/", (TestEmailSend.as_view()), name="test-email"),
     path(
         "activation/confirm/<str:token>",
         ActivationConfirmEmailView.as_view(),

--- a/core/accounts/api/v1/views.py
+++ b/core/accounts/api/v1/views.py
@@ -24,6 +24,8 @@ from django.core.mail import EmailMessage
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.template.loader import render_to_string
 from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 import jwt
 
@@ -131,6 +133,10 @@ class ProfileApiView(generics.RetrieveUpdateAPIView):
     serializer_class = ProfileSerializer
     queryset = Profile.objects.all()
 
+    @method_decorator(cache_page(60 * 5))
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_object(self):
         queryset = self.get_queryset()
         obj = get_object_or_404(queryset, user=self.request.user)
@@ -138,6 +144,7 @@ class ProfileApiView(generics.RetrieveUpdateAPIView):
 
 
 class TestEmailSend(generics.GenericAPIView):
+    @method_decorator(cache_page(60 * 5))
     def get(self, request, *args, **kwargs):
         """This is a create token and send it to the email address of
         the user."""

--- a/core/blog/api/v1/urls/post.py
+++ b/core/blog/api/v1/urls/post.py
@@ -1,8 +1,10 @@
 from rest_framework.routers import DefaultRouter
 from blog.api.v1.views import PostListViewSet
 
+
 app_name = "api-v1"
+
 router = DefaultRouter()
-router.register("post", PostListViewSet, basename="post")
+router.register("post", (PostListViewSet), basename="post")
 
 urlpatterns = router.urls

--- a/core/blog/api/v1/views.py
+++ b/core/blog/api/v1/views.py
@@ -11,6 +11,8 @@ from django.db.models import F
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
 from blog.api.v1.pagination import CustomPagination
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class PostListViewSet(viewsets.ModelViewSet):
@@ -28,6 +30,11 @@ class PostListViewSet(viewsets.ModelViewSet):
     search_fields = ["title", "content"]
     ordering_fields = ["-title", "id", "published_date"]
 
+    @method_decorator(cache_page(60 * 15))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @method_decorator(cache_page(60 * 15))
     def retrieve(self, request, *args, **kwargs):
         post = self.get_object()
         post.views = F("views") + 1
@@ -50,3 +57,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
     filterset_fields = {
         "name": ["exact", "in"],
     }
+
+    @method_decorator(cache_page(60 * 15))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)


### PR DESCRIPTION
Applied @cache_page decorator to list and retrieve methods of PostListViewSet to cache posts list and details for 15 minutes.

Cached the list method in CategoryViewSet for 15 minutes.

Cached the get method in ProfileApiView for 5 minutes.

Cached the get method in TestEmailSend view for 5 minutes.

Improved API performance by reducing database hits.